### PR TITLE
Potential fix for code scanning alert no. 1: Inefficient regular expression

### DIFF
--- a/controladores/validaciones.js
+++ b/controladores/validaciones.js
@@ -3,7 +3,7 @@
 function validarNombre(nombre, llamada){
     var ok = false;
     if (nombre.length > 0 && nombre.length < 20) {
-        var regex = /^[a-zA-ZÀ-ÿ\u00f1\u00d1]+(\s*[a-zA-ZÀ-ÿ\u00f1\u00d1]*)*[a-zA-ZÀ-ÿ\u00f1\u00d1]+$/g;
+        var regex = /^[a-zA-ZÀ-ÿ\u00f1\u00d1]+(\s+[a-zA-ZÀ-ÿ\u00f1\u00d1]+)*$/g;
         if(regex.exec(nombre)){
             ok = true;
         }


### PR DESCRIPTION
Potential fix for [https://github.com/mcn22/Proyecto-Ambiente-Web/security/code-scanning/1](https://github.com/mcn22/Proyecto-Ambiente-Web/security/code-scanning/1)

To fix the inefficiency, we need to remove ambiguity in the repetition branches. The problematic part is `(\s*[a-zA-ZÀ-ÿ\u00f1\u00d1]*)*`, which can match the same string in many ways (e.g., many interleaved spaces and letters).  
A better way: If we want to allow names consisting of letters separated by any amount of spaces, then a robust, unambiguous pattern is:  
- Start with one or more allowed letters.
- Then, repeat groups of (spaces followed by one or more letters).  
This can be written as:  
`^[a-zA-ZÀ-ÿ\u00f1\u00d1]+(\s+[a-zA-ZÀ-ÿ\u00f1\u00d1]+)*$`  
This ensures that each word is a group of letters, separated by spaces (not ambiguous), and avoids allowing a trailing space.

You only need to update line 6, which defines the regex for `validarNombre`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
